### PR TITLE
:bento:  asset: additional examples in playground/rollup-plugin-copy

### DIFF
--- a/playground/rollup-plugin-copy/assets/data/some-folder/b.json
+++ b/playground/rollup-plugin-copy/assets/data/some-folder/b.json
@@ -1,0 +1,6 @@
+{
+  "name": "bob",
+  "male": "male",
+  "age": 42,
+  "the folder containing this file is being watched, and unfortunately, this file is not being copied when waching and it is changed :(": true
+}

--- a/playground/rollup-plugin-copy/assets/data/some/nested/folder/c.json
+++ b/playground/rollup-plugin-copy/assets/data/some/nested/folder/c.json
@@ -1,0 +1,6 @@
+{
+  "name": "carol",
+  "male": "female",
+  "age": 32,
+  "this file is being matched by a glob pattern, which results in it being put directly into the destination directory instead of preserving the directory structure": true
+}

--- a/playground/rollup-plugin-copy/rollup.config.js
+++ b/playground/rollup-plugin-copy/rollup.config.js
@@ -21,6 +21,14 @@ export default {
             return 'Author: guanghechen\n' + source.toString()
           },
         },
+        {
+          src: 'assets/data/some-folder',
+          dest: 'dist/packs',
+        },
+        {
+          src: 'assets/data/some/**/*.json',
+          dest: 'dist/packs',
+        },
       ],
     }),
   ],


### PR DESCRIPTION
This adds examples as requested in #2