### PR TITLE
Declare compatibility of rollup-plugin-copy with rollup v4

### DIFF
--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -52,7 +52,7 @@
     "micromatch": "^4.0.5"
   },
   "peerDependencies": {
-    "rollup": "^2.0.0 || ^3.0.0"
+    "rollup": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@types/dir-glob": "^2.0.2",


### PR DESCRIPTION
According to my tests, the plugin still works perfectly with the new version of Rollup 4.

See https://rollupjs.org/migration/