### PR TITLE
rollup-plugin-copy: Add types to exports field of package.json

### DIFF
--- a/packages/rollup-plugin-copy/package.json
+++ b/packages/rollup-plugin-copy/package.json
@@ -20,6 +20,7 @@
   "type": "module",
   "module": "./lib/esm/index.mjs",
   "exports": {
+    "types": "lib/types/index.d.ts",
     "import": "./lib/esm/index.mjs"
   },
   "types": "lib/types/index.d.ts",


### PR DESCRIPTION
As of Visual Studio Code 1.88, non-TypeScript projects no longer get type guidance on rollup-plugin-copy's options, due to this error:

> Could not find a declaration file for module '@guanghechen/rollup-plugin-copy'. '[...]/node_modules/@guanghechen/rollup-plugin-copy/lib/esm/index.mjs' implicitly has an 'any' type.
>  There are types at '[...]/node_modules/@guanghechen/rollup-plugin-copy/lib/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@guanghechen/rollup-plugin-copy' library may need to update its package.json or typings. ts(7016)

This PR adds the types to the `exports` field so VSCode can find them.